### PR TITLE
docs: update contributor acknowledgment scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,4 +276,4 @@ See [CONTRIBUTING.md](https://github.com/debu-sinha/inspect-mlflow/blob/main/CON
 ## Contributors
 
 - **Debu Sinha** - Creator and maintainer
-- **Vector Institute / National Research Council of Canada (NRC)** - Autolog provider support, contributed on behalf of the Canadian AI Safety Institute (CAISI). Consolidated from [VectorInstitute/inspect-mlflow](https://github.com/VectorInstitute/inspect-mlflow).
+- **Vector Institute / National Research Council of Canada (NRC)** - Autolog provider support and structured Inspect artifact table logging, contributed on behalf of the Canadian AI Safety Institute (CAISI). Consolidated from [VectorInstitute/inspect-mlflow](https://github.com/VectorInstitute/inspect-mlflow).


### PR DESCRIPTION
## What changed and why

Updated the Contributors acknowledgment in `README.md` to reflect contributor scope more clearly.
This is a documentation-only change to keep contributor attribution accurate after consolidation and recent feature work.

## Testing

- [x] `uv run pytest tests/ -v` passes
- [x] `uv run ruff check .` clean
- [x] `uv run mypy inspect_mlflow/` clean
- [ ] New tests added for new functionality

## Checklist

- [x] Read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [x] No breaking changes (or documented in description)
